### PR TITLE
Update redssh.py

### DIFF
--- a/redssh/redssh.py
+++ b/redssh/redssh.py
@@ -182,6 +182,7 @@ class RedSSH(object):
 
     def _auth(self,username,password,allow_agent,host_based,key_filepath,passphrase,look_for_keys):
         auth_supported = self.session.userauth_list(username)
+        if not auth_supported: auth_supported = []
         auth_types_tried = []
 
         if 'publickey' in auth_supported:


### PR DESCRIPTION
If libssh2's session.userauth_list returns no list because authentication is not required then _auth will error out with testing to see if various methods are in auth_supported. So here we're setting auth_supported to an empty list if no types were returned.

Some devices don't require authentication, neither publickey nor password. There's probably a better way to check whether this is required before reaching the _auth function, but this works. 